### PR TITLE
Fix iteration over bytes in UperHex fmt impl

### DIFF
--- a/src/spend/public.rs
+++ b/src/spend/public.rs
@@ -125,9 +125,10 @@ impl fmt::LowerHex for PublicKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes[..] {
-            write!(f, "{:02x}", &byte)?
-        }
+        &bytes[..].iter().for_each(|byte| {
+            write!(f, "{:02X}", &byte)
+                .expect("Unexpected problem while writing bytes.")
+        });
         Ok(())
     }
 }
@@ -140,9 +141,10 @@ impl fmt::UpperHex for PublicKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes[..] {
-            write!(f, "{:02X}", &byte)?
-        }
+        &bytes[..].iter().for_each(|byte| {
+            write!(f, "{:02X}", &byte)
+                .expect("Unexpected problem while writing bytes.")
+        });
         Ok(())
     }
 }

--- a/src/spend/public.rs
+++ b/src/spend/public.rs
@@ -125,7 +125,7 @@ impl fmt::LowerHex for PublicKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02x}", &byte)?
         }
         Ok(())
@@ -140,7 +140,7 @@ impl fmt::UpperHex for PublicKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02X}", &byte)?
         }
         Ok(())

--- a/src/spend/secret.rs
+++ b/src/spend/secret.rs
@@ -114,7 +114,7 @@ impl fmt::LowerHex for SecretKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02x}", &byte)?
         }
         Ok(())
@@ -129,7 +129,7 @@ impl fmt::UpperHex for SecretKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02X}", &byte)?
         }
         Ok(())

--- a/src/spend/secret.rs
+++ b/src/spend/secret.rs
@@ -114,9 +114,10 @@ impl fmt::LowerHex for SecretKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes[..] {
-            write!(f, "{:02x}", &byte)?
-        }
+        &bytes[..].iter().for_each(|byte| {
+            write!(f, "{:02X}", &byte)
+                .expect("Unexpected problem while writing bytes.")
+        });
         Ok(())
     }
 }
@@ -129,9 +130,10 @@ impl fmt::UpperHex for SecretKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes[..] {
-            write!(f, "{:02X}", &byte)?
-        }
+        &bytes[..].iter().for_each(|byte| {
+            write!(f, "{:02X}", &byte)
+                .expect("Unexpected problem while writing bytes.")
+        });
         Ok(())
     }
 }

--- a/src/spend/stealth.rs
+++ b/src/spend/stealth.rs
@@ -121,7 +121,7 @@ impl fmt::LowerHex for StealthAddress {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02x}", &byte)?
         }
         Ok(())
@@ -136,7 +136,7 @@ impl fmt::UpperHex for StealthAddress {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02X}", &byte)?
         }
         Ok(())

--- a/src/spend/stealth.rs
+++ b/src/spend/stealth.rs
@@ -121,9 +121,10 @@ impl fmt::LowerHex for StealthAddress {
             write!(f, "0x")?
         }
 
-        for byte in &bytes[..] {
-            write!(f, "{:02x}", &byte)?
-        }
+        &bytes[..].iter().for_each(|byte| {
+            write!(f, "{:02X}", &byte)
+                .expect("Unexpected problem while writing bytes.")
+        });
         Ok(())
     }
 }
@@ -136,9 +137,10 @@ impl fmt::UpperHex for StealthAddress {
             write!(f, "0x")?
         }
 
-        for byte in &bytes[..] {
-            write!(f, "{:02X}", &byte)?
-        }
+        &bytes[..].iter().for_each(|byte| {
+            write!(f, "{:02X}", &byte)
+                .expect("Unexpected problem while writing bytes.")
+        });
         Ok(())
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -133,7 +133,7 @@ impl fmt::LowerHex for ViewKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02x}", &byte)?
         }
         Ok(())
@@ -148,7 +148,7 @@ impl fmt::UpperHex for ViewKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02X}", &byte)?
         }
         Ok(())

--- a/src/view.rs
+++ b/src/view.rs
@@ -133,9 +133,10 @@ impl fmt::LowerHex for ViewKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes[..] {
-            write!(f, "{:02x}", &byte)?
-        }
+        &bytes[..].iter().for_each(|byte| {
+            write!(f, "{:02X}", &byte)
+                .expect("Unexpected problem while writing bytes.")
+        });
         Ok(())
     }
 }
@@ -148,9 +149,10 @@ impl fmt::UpperHex for ViewKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes[..] {
-            write!(f, "{:02X}", &byte)?
-        }
+        &bytes[..].iter().for_each(|byte| {
+            write!(f, "{:02X}", &byte)
+                .expect("Unexpected problem while writing bytes.")
+        });
         Ok(())
     }
 }


### PR DESCRIPTION
The data structures we have were being displayed
& formatted by being converted to UpperHex.
The problem was that these were trying to iterate over
the array whitout converting it to an Iter.

It has been fixed by forcing the iteration over slices
so we don't need to copy.

Review this and merge this before #7 gets merged.