### PR TITLE
Revert  #8 from dusk-network/fix_err"

### DIFF
--- a/src/spend/public.rs
+++ b/src/spend/public.rs
@@ -1,5 +1,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
-// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for
+// details.
 
 use super::secret::SecretKey;
 use super::stealth::StealthAddress;
@@ -125,10 +126,9 @@ impl fmt::LowerHex for PublicKey {
             write!(f, "0x")?
         }
 
-        bytes[..].iter().for_each(|byte| {
-            write!(f, "{:02X}", &byte)
-                .expect("Unexpected problem while writing bytes.")
-        });
+        for byte in &bytes {
+            write!(f, "{:02x}", &byte)?
+        }
         Ok(())
     }
 }
@@ -141,10 +141,9 @@ impl fmt::UpperHex for PublicKey {
             write!(f, "0x")?
         }
 
-        bytes[..].iter().for_each(|byte| {
-            write!(f, "{:02X}", &byte)
-                .expect("Unexpected problem while writing bytes.")
-        });
+        for byte in &bytes {
+            write!(f, "{:02X}", &byte)?
+        }
         Ok(())
     }
 }

--- a/src/spend/public.rs
+++ b/src/spend/public.rs
@@ -126,7 +126,7 @@ impl fmt::LowerHex for PublicKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02x}", &byte)?
         }
         Ok(())
@@ -141,7 +141,7 @@ impl fmt::UpperHex for PublicKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02X}", &byte)?
         }
         Ok(())

--- a/src/spend/secret.rs
+++ b/src/spend/secret.rs
@@ -115,7 +115,7 @@ impl fmt::LowerHex for SecretKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02x}", &byte)?
         }
         Ok(())
@@ -130,7 +130,7 @@ impl fmt::UpperHex for SecretKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02X}", &byte)?
         }
         Ok(())

--- a/src/spend/secret.rs
+++ b/src/spend/secret.rs
@@ -1,5 +1,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
-// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for
+// details.
 
 use super::public::PublicKey;
 use super::stealth::StealthAddress;
@@ -114,10 +115,9 @@ impl fmt::LowerHex for SecretKey {
             write!(f, "0x")?
         }
 
-        bytes[..].iter().for_each(|byte| {
-            write!(f, "{:02X}", &byte)
-                .expect("Unexpected problem while writing bytes.")
-        });
+        for byte in &bytes {
+            write!(f, "{:02x}", &byte)?
+        }
         Ok(())
     }
 }
@@ -130,10 +130,9 @@ impl fmt::UpperHex for SecretKey {
             write!(f, "0x")?
         }
 
-        bytes[..].iter().for_each(|byte| {
-            write!(f, "{:02X}", &byte)
-                .expect("Unexpected problem while writing bytes.")
-        });
+        for byte in &bytes {
+            write!(f, "{:02X}", &byte)?
+        }
         Ok(())
     }
 }

--- a/src/spend/stealth.rs
+++ b/src/spend/stealth.rs
@@ -1,5 +1,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
-// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for
+// details.
 
 use crate::{decode::decode, Error, JubJubAffine, JubJubExtended};
 
@@ -121,10 +122,9 @@ impl fmt::LowerHex for StealthAddress {
             write!(f, "0x")?
         }
 
-        bytes[..].iter().for_each(|byte| {
-            write!(f, "{:02X}", &byte)
-                .expect("Unexpected problem while writing bytes.")
-        });
+        for byte in &bytes {
+            write!(f, "{:02x}", &byte)?
+        }
         Ok(())
     }
 }
@@ -137,10 +137,9 @@ impl fmt::UpperHex for StealthAddress {
             write!(f, "0x")?
         }
 
-        bytes[..].iter().for_each(|byte| {
-            write!(f, "{:02X}", &byte)
-                .expect("Unexpected problem while writing bytes.")
-        });
+        for byte in &bytes {
+            write!(f, "{:02X}", &byte)?
+        }
         Ok(())
     }
 }

--- a/src/spend/stealth.rs
+++ b/src/spend/stealth.rs
@@ -122,7 +122,7 @@ impl fmt::LowerHex for StealthAddress {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02x}", &byte)?
         }
         Ok(())
@@ -137,7 +137,7 @@ impl fmt::UpperHex for StealthAddress {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02X}", &byte)?
         }
         Ok(())

--- a/src/view.rs
+++ b/src/view.rs
@@ -134,7 +134,7 @@ impl fmt::LowerHex for ViewKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02x}", &byte)?
         }
         Ok(())
@@ -149,7 +149,7 @@ impl fmt::UpperHex for ViewKey {
             write!(f, "0x")?
         }
 
-        for byte in &bytes {
+        for byte in &bytes[..] {
             write!(f, "{:02X}", &byte)?
         }
         Ok(())

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,5 +1,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
-// Licensed under the MPL 2.0 license. See LICENSE file in the project root for details.
+// Licensed under the MPL 2.0 license. See LICENSE file in the project root for
+// details.
 
 use crate::spend::stealth;
 use crate::sponge;
@@ -133,10 +134,9 @@ impl fmt::LowerHex for ViewKey {
             write!(f, "0x")?
         }
 
-        bytes[..].iter().for_each(|byte| {
-            write!(f, "{:02X}", &byte)
-                .expect("Unexpected problem while writing bytes.")
-        });
+        for byte in &bytes {
+            write!(f, "{:02x}", &byte)?
+        }
         Ok(())
     }
 }
@@ -149,10 +149,9 @@ impl fmt::UpperHex for ViewKey {
             write!(f, "0x")?
         }
 
-        bytes[..].iter().for_each(|byte| {
-            write!(f, "{:02X}", &byte)
-                .expect("Unexpected problem while writing bytes.")
-        });
+        for byte in &bytes {
+            write!(f, "{:02X}", &byte)?
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Revert the changes introduced in #8 due to a wrong compiler version in @CPerezz local machine which produced errors that are not existing in newer Rust versions.