### PR TITLE
Bump poseidon & jubjub deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2018"
 
 [dependencies]
-poseidon252 = { git = "https://github.com/dusk-network/Poseidon252", tag = "v0.6.3"}
+poseidon252 = { git = "https://github.com/dusk-network/Poseidon252", tag = "v0.8.0"}
 dusk-jubjub = "0.3.7"
 hex = "^0.4"
 rand = "^0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "dusk-pki"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2018"
 
 [dependencies]
 poseidon252 = { git = "https://github.com/dusk-network/Poseidon252", tag = "v0.8.0"}
-dusk-jubjub = "0.3.7"
+dusk-jubjub = "0.3.8"
 hex = "^0.4"
 rand = "^0.7"
 sha2 = "0.8"


### PR DESCRIPTION
These deps are outdated in respect to the actual ones used across the rest of our stack. This PR fixes that problem.