### PR TITLE
Increase tag number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-pki"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2018"
 


### PR DESCRIPTION
Increase the tag from v0.3.0 to v0.3.1 for a new minor release. This closes #21 