### PR TITLE
Use poseidon252 as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 26-11-20
+### Changed
+- Use poseidon252 dependency.
+
 ## [0.4.0] - 17-11-20
 ### Changed
 - No-Std compatibility.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-pki"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2018"
 
@@ -8,7 +8,7 @@ edition = "2018"
 rand_core = "0.5.1"
 dusk-bls12_381 = {version = "0.3", default-features = false}
 dusk-jubjub = {version = "0.5", default-features = false}
-hades252 = {git = "https://github.com/dusk-network/hades252", tag = "v0.10.1", default-features = false}
+poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.14.1", default-features = false}
 hex = {version = "^0.4", default-features = false}
 subtle = {version = "^2.2.1", default-features = false}
 canonical = {version = "0.4", optional = true}
@@ -21,7 +21,7 @@ default = ["std"]
 std = [
     "dusk-jubjub/default",
     "dusk-bls12_381/default",
-    "hades252/default",
+    "poseidon252/default",
     "subtle/default",
     "hex/default",
     "rand/default",

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -6,20 +6,11 @@
 
 use crate::{JubJubExtended, JubJubScalar};
 
-use dusk_bls12_381::BlsScalar;
-use hades252::{ScalarStrategy, Strategy};
-
-use core::cmp;
+use poseidon252::sponge;
 
 /// Hashes a JubJub's ExtendedPoint into a JubJub's Scalar
 pub fn hash(p: &JubJubExtended) -> JubJubScalar {
-    let mut perm = [BlsScalar::zero(); hades252::WIDTH];
-    let p = p.to_hash_inputs();
+    let h = sponge::hash(&p.to_hash_inputs());
 
-    let n = cmp::min(hades252::WIDTH, p.len());
-
-    perm[0..n].copy_from_slice(&p[0..n]);
-    ScalarStrategy::new().perm(&mut perm);
-
-    JubJubScalar::from_raw(perm[1].reduce().0)
+    JubJubScalar::from_raw(h.reduce().0)
 }


### PR DESCRIPTION
Any permutation should be centralized in poseidon252 crate to avoid
duplicated code.