### PR TITLE
Update deps to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `canonical` from v0.5.0 to v0.6.0 [#44](https://github.com/dusk-network/dusk-pki/issues/44)
+- Update `rand_core` from v0.5.0 to v0.6.0 [#44](https://github.com/dusk-network/dusk-pki/issues/44)
+- Update `dusk-jubjub` from v0.8.0 to v0.10.0 [#44](https://github.com/dusk-network/dusk-pki/issues/44)
+- Update `dusk-poseidon` from v0.20.0 to v0.21.0-rc.0 [#44](https://github.com/dusk-network/dusk-pki/issues/44)
+
+### Removed
+
+- Remove `rand` from dev-dependencies [#44](https://github.com/dusk-network/dusk-pki/issues/44)
+
 ## [0.6.2] - 2021-04-06
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,15 @@ license = "MPL-2.0"
 exclude = [".github/workflows/ci.yml", ".gitignore"]
 
 [dependencies]
-rand_core = "0.5"
+rand_core = "0.6"
 dusk-bytes = "0.1"
 subtle = {version="^2.2.1", default-features=false}
-dusk-jubjub = {version="0.8", default-features=false}
-dusk-poseidon = {version="0.20", default-features = false}
-canonical = {version = "0.5", optional = true}
-canonical_derive = {version = "0.5", optional = true}
+dusk-jubjub = {version="0.10.0", default-features=false}
+dusk-poseidon = {version="0.21.0-rc.0", default-features = false}
+canonical = {version = "0.6", optional = true}
+canonical_derive = {version = "0.6", optional = true}
 
 [dev-dependencies]
-rand ="0.7"
 sha2 = "0.8"
 
 [features]

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -10,8 +10,6 @@ use dusk_bytes::{Error, HexDebug, Serializable};
 use dusk_jubjub::GENERATOR_EXTENDED;
 
 #[cfg(feature = "canon")]
-use canonical::Canon;
-#[cfg(feature = "canon")]
 use canonical_derive::Canon;
 
 /// Structure repesenting a [`PublicKey`]

--- a/src/keys/secret.rs
+++ b/src/keys/secret.rs
@@ -9,8 +9,6 @@ use dusk_bytes::{Error, HexDebug, Serializable};
 use rand_core::{CryptoRng, RngCore};
 
 #[cfg(feature = "canon")]
-use canonical::Canon;
-#[cfg(feature = "canon")]
 use canonical_derive::Canon;
 
 #[allow(non_snake_case)]

--- a/src/keys/spend/public.rs
+++ b/src/keys/spend/public.rs
@@ -12,8 +12,6 @@ use crate::{
 use super::secret::SecretSpendKey;
 
 #[cfg(feature = "canon")]
-use canonical::Canon;
-#[cfg(feature = "canon")]
 use canonical_derive::Canon;
 
 use dusk_bytes::{DeserializableSlice, Error, HexDebug, Serializable};

--- a/src/keys/spend/secret.rs
+++ b/src/keys/spend/secret.rs
@@ -10,8 +10,6 @@ use super::public::PublicSpendKey;
 use super::stealth::StealthAddress;
 
 #[cfg(feature = "canon")]
-use canonical::Canon;
-#[cfg(feature = "canon")]
 use canonical_derive::Canon;
 
 use dusk_bytes::{DeserializableSlice, Error, HexDebug, Serializable};

--- a/src/keys/spend/stealth.rs
+++ b/src/keys/spend/stealth.rs
@@ -5,8 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::{JubJubAffine, JubJubExtended, PublicKey};
-#[cfg(feature = "canon")]
-use canonical::Canon;
+
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
 use dusk_bytes::{DeserializableSlice, Error, HexDebug, Serializable};

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,36 +5,22 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 mod std_tests {
-    use dusk_bytes::ParseHexStr;
+    use dusk_bytes::{DeserializableSlice, ParseHexStr, Serializable};
     use dusk_pki::{PublicSpendKey, SecretSpendKey, ViewKey};
-    use rand::SeedableRng;
-    fn ssk_from_str(s: &str) -> SecretSpendKey {
-        use rand::rngs::StdRng;
-        use sha2::{Digest, Sha256};
-
-        let bytes = s.as_bytes();
-
-        let mut hasher = Sha256::default();
-        hasher.input(bytes);
-        let bytes = hasher.result();
-
-        let mut seed = [0u8; 32];
-        seed.copy_from_slice(&bytes[..32]);
-
-        SecretSpendKey::random(&mut StdRng::from_seed(seed))
-    }
+    use rand_core::OsRng;
 
     #[test]
     fn ssk_from_bytes() {
-        let ssk_a = ssk_from_str("some bytes");
-        let ssk_b = ssk_from_str("some bytes");
+        let ssk_a = SecretSpendKey::random(&mut OsRng);
+        let bytes = ssk_a.to_bytes();
+        let ssk_b = SecretSpendKey::from_slice(&bytes).expect("Serde error");
 
         assert_eq!(ssk_a, ssk_b);
     }
 
     #[test]
     fn keys_encoding() {
-        let ssk = ssk_from_str("some bytes");
+        let ssk = SecretSpendKey::random(&mut OsRng);
         let vk = ssk.view_key();
         let psk = ssk.public_spend_key();
 
@@ -53,15 +39,15 @@ mod std_tests {
     fn keys_consistency() {
         use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED};
 
-        let r = JubJubScalar::random(&mut rand::thread_rng());
-        let ssk = SecretSpendKey::random(&mut rand::thread_rng());
+        let r = JubJubScalar::random(&mut OsRng);
+        let ssk = SecretSpendKey::random(&mut OsRng);
         let psk = ssk.public_spend_key();
         let vk = ssk.view_key();
         let sa = psk.gen_stealth_address(&r);
 
         assert!(vk.owns(&sa));
 
-        let wrong_ssk = SecretSpendKey::random(&mut rand::thread_rng());
+        let wrong_ssk = SecretSpendKey::random(&mut OsRng);
         let wrong_vk = wrong_ssk.view_key();
 
         assert_ne!(ssk, wrong_ssk);


### PR DESCRIPTION
- Update `canonical` from v0.5.0 to v0.6.0
- Update `rand_core` from v0.5.0 to v0.6.0
- Update `dusk-jubjub` from v0.8.0 to v0.10.0
- Update `dusk-poseidon` from v0.20.0 to v0.21.0-rc.0
- Remove `rand` from dev-deps section

Resolves: #44 