### PR TITLE
Change `PartialEq` and `Eq` impls for `PublicKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `PartialEq` and `Eq` impls for `PublicKey`
+
 ## [0.7.0] - 2021-07-05
 
 ### Changed

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -27,9 +27,9 @@ impl From<&SecretKey> for PublicKey {
 
 impl PartialEq for PublicKey {
     fn eq(&self, other: &Self) -> bool {
-        let z_z_prime = self.0.get_z() * other.0.get_z();
-        self.0.get_x() * z_z_prime == other.0.get_z() * z_z_prime
-            && self.0.get_y() * z_z_prime == other.0.get_y() * z_z_prime
+        self.0.get_x() * other.0.get_z() == other.0.get_x() * self.0.get_z()
+            && self.0.get_y() * other.0.get_z()
+                == other.0.get_y() * self.0.get_z()
     }
 }
 
@@ -70,11 +70,40 @@ mod tests {
     #[test]
     fn partial_eq_test() {
         use super::*;
+        use dusk_jubjub::{JubJubAffine, JubJubScalar};
         use rand_core::OsRng;
-        let sk1 = SecretKey::random(&mut OsRng);
-        let sk2 = SecretKey::random(&mut OsRng);
+
+        let sk1 = PublicKey::from(&SecretKey::random(&mut OsRng));
+        let sk2 = PublicKey::from(&SecretKey::random(&mut OsRng));
 
         assert_eq!(sk1, sk1);
-        assert_ne!(sk1, sk2)
+        assert_ne!(sk1, sk2);
+
+        // With all coordinates being different the points are the same ie.
+        // equalty holds using this technique.
+        let a = JubJubScalar::from(2u64);
+        let b = JubJubScalar::from(7u64);
+        let c = JubJubScalar::from(4u64);
+        let d = JubJubScalar::from(5u64);
+        let e = JubJubScalar::from(567758785u64);
+
+        let left: JubJubExtended = dusk_jubjub::GENERATOR_EXTENDED * a
+            + dusk_jubjub::GENERATOR_EXTENDED * b;
+
+        let right: JubJubExtended = dusk_jubjub::GENERATOR_EXTENDED * c
+            + dusk_jubjub::GENERATOR_EXTENDED * d;
+
+        let wrong: JubJubExtended = dusk_jubjub::GENERATOR_EXTENDED * c
+            + dusk_jubjub::GENERATOR_EXTENDED * e;
+
+        // Assert none of the points coordinates actually matches
+        assert_ne!(left.get_x(), right.get_x());
+        assert_ne!(left.get_y(), right.get_y());
+        assert_ne!(left.get_z(), right.get_z());
+
+        assert_eq!(JubJubAffine::from(right), JubJubAffine::from(left));
+
+        assert_eq!(PublicKey::from(left), PublicKey::from(right));
+        assert_ne!(PublicKey::from(left), PublicKey::from(wrong))
     }
 }


### PR DESCRIPTION
This helps to avoid converting each `JubJubExtended` into
Affine coordinates each time and instead just perform 5 field
elemet multiplications

Resolves: #53