### PR TITLE
Add `const` fn `PublicKey` and `StealthAddress`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `PublicKey::from_raw_unchecked` and `StealthAddress::from_raw_unchecked` [#63]
+
 ### Changed
 
 - Update `dusk-jubjub` from `0.10` to `0.11`
 - Update `dusk-poseidon` from `0.24.0-rc` to `0.25.0-rc`
 - Update `canonical` from `0.6` to `0.7`
 - Update `canonical_derive` from `0.6` to `0.7`
+- Update `StealthAddress::R` and `StealthAddress::pk_r` to `const fn` [#63]
 
 ## [0.8.0] - 2021-07-27
 
@@ -106,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No-Std compatibility.
 
+[#63]: https://github.com/dusk-network/dusk-pki/issues/63
 [#60]: https://github.com/dusk-network/dusk-pki/issues/60
 [#54]: https://github.com/dusk-network/dusk-pki/issues/54
 [#53]: https://github.com/dusk-network/dusk-pki/issues/53

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-pki"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2021"
 

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -64,3 +64,19 @@ impl Serializable<32> for PublicKey {
         Ok(Self(JubJubAffine::from_bytes(bytes)?.into()))
     }
 }
+
+impl PublicKey {
+    /// Create a public key from its internal parts
+    ///
+    /// The public keys are generated from a bijective function that takes a
+    /// secret keys domain. If keys are generated directly from curve
+    /// points, there is no guarantee a secret key exists - in fact, the
+    /// discrete logarithm property will guarantee the secret key cannot be
+    /// extracted from this public key.
+    ///
+    /// If you opt to generate the keys manually, be sure you have its secret
+    /// counterpart - otherwise this key will be of no use.
+    pub const fn from_raw_unchecked(key: JubJubExtended) -> Self {
+        Self(key)
+    }
+}

--- a/src/keys/spend/stealth.rs
+++ b/src/keys/spend/stealth.rs
@@ -31,13 +31,29 @@ pub trait Ownable {
 }
 
 impl StealthAddress {
+    /// Create a stealth address from its internal parts
+    ///
+    /// A stealth address is intended to be generated as the public counterpart
+    /// of a one time secrete spend key. If the user opts to generate the
+    /// stealth address from points, there is no guarantee a secret one time
+    /// spend key counterpart will be known, and this stealth address will
+    /// not provide the required arguments to generate it.
+    ///
+    /// For additional information, check [PublicKey::from_raw_unchecked].
+    pub const fn from_raw_unchecked(
+        R: JubJubExtended,
+        pk_r: PublicKey,
+    ) -> Self {
+        Self { R, pk_r }
+    }
+
     /// Gets the random point `R`
-    pub fn R(&self) -> &JubJubExtended {
+    pub const fn R(&self) -> &JubJubExtended {
         &self.R
     }
 
     /// Gets the `pk_r`
-    pub fn pk_r(&self) -> &PublicKey {
+    pub const fn pk_r(&self) -> &PublicKey {
         &self.pk_r
     }
 


### PR DESCRIPTION
We have some special use-cases for constant one-time keys in Rusk where
we need to pad zeroed outputs to transactions in order to satisfy the
ZK circuit.

Using runtime calculation for objects that should be constants is
cryptic and inefficient.

Resolves #63