### PR TITLE
Bump version to `0.11.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2022-10-19
+
 ### Added
 
 - Add support for `rkyv-impl` under `no_std`
@@ -130,7 +132,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#38]: https://github.com/dusk-network/dusk-pki/issues/38
 [#36]: https://github.com/dusk-network/dusk-pki/issues/36
 [#34]: https://github.com/dusk-network/dusk-pki/issues/34
-[unreleased]: https://github.com/dusk-network/dusk-pki/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/dusk-network/dusk-pki/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/dusk-network/dusk-pki/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/dusk-network/dusk-pki/compare/v0.8.0...v0.11.0
 [0.8.0]: https://github.com/dusk-network/dusk-pki/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/dusk-network/dusk-pki/compare/v0.6.2...v0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-pki"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2021"
 


### PR DESCRIPTION
### Added

- Add support for `rkyv-impl` under `no_std`