### PR TITLE
Derive `Default` for `PublicKey`

### DIFF
--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -16,7 +16,7 @@ use canonical_derive::Canon;
 use rkyv::{Archive, Deserialize, Serialize};
 
 /// Structure repesenting a [`PublicKey`]
-#[derive(Copy, Clone, HexDebug)]
+#[derive(Default, Copy, Clone, HexDebug)]
 #[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",


### PR DESCRIPTION
`Citadel` requires it for handling the `License` struct.