### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -33,19 +33,6 @@ jobs:
           command: test
           args: --release
 
-  test_nightly_canon:
-    name: Nightly tests canon
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --features canon
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `dusk-poseidon` from `0.30` to `0.31`
+- Update `dusk-jubjub` from `0.12` to `0.13`
+
+### Removed
+
+- Remove `canonical` dependencies and features
+
 ## [0.12.0] - 2023-06-28
+
+### Changed
 
 - Update `dusk-poseidon` from `0.28` to `0.30`
 - Update `rust-toolchain` from `nightly-2022-08-08` to `nightly-2023-05-22`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,8 @@ exclude = [".github/workflows/ci.yml", ".gitignore"]
 rand_core = { version = "0.6", default-features = false }
 dusk-bytes = "0.1"
 subtle = { version = "^2.2.1", default-features = false }
-dusk-jubjub = { version = "0.12", default-features = false }
-dusk-poseidon = { version = "0.30", default-features = false }
-canonical = { version = "0.7", optional = true }
-canonical_derive = { version = "0.7", optional = true }
+dusk-jubjub = { version = "0.13", default-features = false }
+dusk-poseidon = { version = "0.31", default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
 
@@ -27,9 +25,4 @@ rand_core = { version = "0.6", default-features = false, features = ["getrandom"
 sha2 = "0.8"
 
 [features]
-canon = [
-    "canonical",
-    "canonical_derive",
-    "dusk-jubjub/canon"
-]
 rkyv-impl = ["dusk-jubjub/rkyv-impl", "rkyv", "bytecheck"]

--- a/src/keys/secret.rs
+++ b/src/keys/secret.rs
@@ -8,16 +8,12 @@ use crate::JubJubScalar;
 use dusk_bytes::{Error, HexDebug, Serializable};
 use rand_core::{CryptoRng, RngCore};
 
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
 /// Structure repesenting a secret key
 #[allow(non_snake_case)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, HexDebug)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),
@@ -64,6 +60,10 @@ impl Serializable<32> for SecretKey {
     }
 
     fn from_bytes(bytes: &[u8; 32]) -> Result<Self, Error> {
-        Ok(Self(JubJubScalar::from_bytes(bytes)?))
+        let secret_key = match JubJubScalar::from_bytes(bytes).into() {
+            Some(sk) => sk,
+            None => return Err(Error::InvalidData),
+        };
+        Ok(Self(secret_key))
     }
 }

--- a/src/keys/spend/public.rs
+++ b/src/keys/spend/public.rs
@@ -11,9 +11,6 @@ use crate::{
 
 use super::secret::SecretSpendKey;
 
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -23,7 +20,6 @@ use subtle::{Choice, ConstantTimeEq};
 
 /// Public pair of `a·G` and `b·G` defining a [`PublicSpendKey`]
 #[derive(HexDebug, Clone, Copy)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),

--- a/src/keys/spend/secret.rs
+++ b/src/keys/spend/secret.rs
@@ -9,9 +9,6 @@ use crate::{permutation, JubJubScalar, SecretKey, ViewKey};
 use super::public::PublicSpendKey;
 use super::stealth::StealthAddress;
 
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
-
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -22,7 +19,6 @@ use subtle::{Choice, ConstantTimeEq};
 
 /// Secret pair of `a` and `b` defining a [`SecretSpendKey`]
 #[derive(Clone, Copy, Eq, HexDebug)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),

--- a/src/keys/spend/stealth.rs
+++ b/src/keys/spend/stealth.rs
@@ -6,8 +6,6 @@
 
 use crate::{JubJubAffine, JubJubExtended, PublicKey};
 
-#[cfg(feature = "canon")]
-use canonical_derive::Canon;
 use dusk_bytes::{DeserializableSlice, Error, HexDebug, Serializable};
 
 use subtle::{Choice, ConstantTimeEq};
@@ -20,7 +18,6 @@ use rkyv::{Archive, Deserialize, Serialize};
 /// A `StealthAddress` is composed by a one-time public key (`pk_r`, the actual
 // address) and a random point `R`.
 #[derive(Default, HexDebug, Clone, Copy)]
-#[cfg_attr(feature = "canon", derive(Canon))]
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -95,8 +95,8 @@ fn partial_eq_pk() {
         + dusk_jubjub::GENERATOR_EXTENDED * s.4;
 
     // Assert none of the points coordinates actually matches
-    assert_ne!(left.get_x(), right.get_x());
-    assert_ne!(left.get_y(), right.get_y());
+    assert_ne!(left.get_u(), right.get_u());
+    assert_ne!(left.get_v(), right.get_v());
     assert_ne!(left.get_z(), right.get_z());
 
     assert_eq!(JubJubAffine::from(right), JubJubAffine::from(left));


### PR DESCRIPTION
- Update `dusk-poseidon` from `0.30` to `0.31`
- Update `dusk-jubjub` from `0.12` to `0.13`
- Remove `canonical` dependencies and features