### PR TITLE
Bump to v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2023-10-12
+
 ### Changed
 
 - Update `dusk-poseidon` from `0.30` to `0.31`
@@ -166,7 +168,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#38]: https://github.com/dusk-network/dusk-pki/issues/38
 [#36]: https://github.com/dusk-network/dusk-pki/issues/36
 [#34]: https://github.com/dusk-network/dusk-pki/issues/34
-[Unreleased]: https://github.com/dusk-network/dusk-pki/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/dusk-network/dusk-pki/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/dusk-network/dusk-pki/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/dusk-network/dusk-pki/compare/v0.11.4...v0.12.0
 [0.11.4]: https://github.com/dusk-network/dusk-pki/compare/v0.11.3...v0.11.4
 [0.11.3]: https://github.com/dusk-network/dusk-pki/compare/v0.11.2...v0.11.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusk-pki"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network>"]
 edition = "2021"
 


### PR DESCRIPTION
## [0.13.0] - 2023-10-12

### Changed

- Update `dusk-poseidon` from `0.30` to `0.31`
- Update `dusk-jubjub` from `0.12` to `0.13`

### Removed

- Remove `canonical` dependencies and features

[0.13.0]: https://github.com/dusk-network/dusk-pki/compare/v0.12.0...v0.13.0
