### PR TITLE
Add deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added deprecation notice [#79]
+
 ## [0.13.0] - 2023-10-12
 
 ### Changed
@@ -156,6 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No-Std compatibility.
 
+[#79]: https://github.com/dusk-network/dusk-pki/issues/79
 [#66]: https://github.com/dusk-network/dusk-pki/issues/66
 [#63]: https://github.com/dusk-network/dusk-pki/issues/63
 [#60]: https://github.com/dusk-network/dusk-pki/issues/60

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# dusk-pki
+# dusk-pki (Deprecated)
+## This repository is deprecated
+> Functionalities from this repository are now residing in dusk-schnorr and phoenix-core.
 
 ![Build Status](https://github.com/dusk-network/dusk-pki/workflows/Continuous%20integration/badge.svg)
 [![Repository](https://img.shields.io/badge/github-dusk--pki-blueviolet?logo=github)](https://github.com/dusk-network/dusk-pki)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! This repository has been created so there's a unique library that holds the
 //! types and functions required to perform keys operations.
-
+#![deprecated = "This crate is deprecated. The code was moved to dusk-schnorr and phoenix-core."]
 #![no_std]
 #![deny(missing_docs)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
We can deprecate this repository and close https://github.com/dusk-network/dusk-pki/issues/79. The issues referred to in https://github.com/dusk-network/dusk-pki/issues/79 (https://github.com/dusk-network/schnorr/issues/80 & https://github.com/dusk-network/phoenix-core/issues/126) are already resolved.